### PR TITLE
Make F32 python3 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-# radeon-tools
-
-Tools for working with various radeon related files, as released by fail0verflow.
-See individual directories for detailed information.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# radeon-tools
+
+Tools for working with various radeon related files, as released by fail0verflow.
+See individual directories for detailed information.

--- a/f32/README.md
+++ b/f32/README.md
@@ -22,7 +22,7 @@ Note that some registers are special:
 ### Usage
 
 ```shell
-$ python f32dis.py /lib/firmware/radeon/LIVERPOOL_pfp.bin
+$ python3 f32dis.py /lib/firmware/radeon/LIVERPOOL_pfp.bin
    0  c4340025 | ldw r13, [r0, #0x25]
    1  c438001e | ldw r14, [r0, #0x1e]
    2  9740000b | cbz r13, 0xd

--- a/f32/f32dis.py
+++ b/f32/f32dis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 import sys, struct, os.path
 
 packet3 = {
@@ -266,7 +266,7 @@ def jmptab(val):
 
 FMT = ">I"
 
-with open(sys.argv[1], "r") as fd:
+with open(sys.argv[1], "rb") as fd:
     base = os.path.split(sys.argv[1])[-1]
     if base.lower() == base:
         fd.read(0x100)
@@ -292,28 +292,28 @@ for i in range(code_size, total_size, 4):
 for i in range(0, total_size, 4):
     inst = struct.unpack(FMT, data[i:i+4])[0]
     if i < code_size:
-        dis(i/4, inst)
+        dis(i//4, inst)
 
 # second pass, assign labels
 for i in range(0, total_size, 4):
     inst = struct.unpack(FMT, data[i:i+4])[0]
-    if i/4 in jtab:
+    if i//4 in jtab:
         lct = 0
-        lpref = labels[i/4]
-    if i/4 in labels and labels[i/4] == True:
-        labels[i/4] = "_%s_%d" % (lpref, lct)
+        lpref = labels[i//4]
+    if i//4 in labels and labels[i//4] == True:
+        labels[i//4] = "_%s_%d" % (lpref, lct)
         lct += 1
     if i < code_size:
-        dis(i/4, inst)
+        dis(i//4, inst)
 
 # third pass, disassemble
 for i in range(0, total_size, 4):
     inst = struct.unpack(FMT, data[i:i+4])[0]
-    if i/4 in labels:
-        if i/4 in jtab:
-            print
-        print labels[i/4] + ":"
+    if i//4 in labels:
+        if i//4 in jtab:
+            print("")
+        print(labels[i//4] + ":")
     if i < code_size:
-        print "    %s" % (dis(i/4, inst))
+        print("    %s" % (dis(i//4, inst)))
     else:
-        print "#J%s" % (jmptab(inst))
+        print("#J%s" % (jmptab(inst)))

--- a/f32/resize_firmware.md
+++ b/f32/resize_firmware.md
@@ -11,7 +11,7 @@ size.
 To convert Bonaire firmware to work on Liverpool:
 
 ```shell
-python2 resize_firmware.py bonaire_pfp.bin 17024 liverpool_pfp.bin
-python2 resize_firmware.py bonaire_me.bin 17024 liverpool_me.bin
+python3 resize_firmware.py bonaire_pfp.bin 17024 liverpool_pfp.bin
+python3 resize_firmware.py bonaire_me.bin 17024 liverpool_me.bin
 cp bonaire_ce.bin liverpool_ce.bin  # already the correct size
 ```

--- a/f32/resize_firmware.py
+++ b/f32/resize_firmware.py
@@ -1,10 +1,11 @@
+#!/usr/bin/python3
 import zlib, sys, struct 
 
 want_size = int(sys.argv[2]) - 0x100
 want_blob_sz = want_size & ~0xfff
 want_jt_sz = want_size & 0xfff
 
-print "want: 0x%x / 0x%x / 0x%x (total, blob, jt)" % (want_size, want_blob_sz, want_jt_sz)
+print("want: 0x%x / 0x%x / 0x%x (total, blob, jt)" % (want_size, want_blob_sz, want_jt_sz))
 
 with open(sys.argv[1], "rb") as fd:
     hdr = fd.read(0x20)
@@ -21,19 +22,19 @@ ucode_jt_sz = ucode_size & 0xfff
 ucode_blob = ucode[:ucode_blob_sz]
 ucode_jt = ucode[ucode_blob_sz:]
 
-print "have: 0x%x / 0x%x / 0x%x (total, blob, jt)" % (ucode_size, ucode_blob_sz, ucode_jt_sz)
+print("have: 0x%x / 0x%x / 0x%x (total, blob, jt)" % (ucode_size, ucode_blob_sz, ucode_jt_sz))
 
 if ucode_blob_sz < want_blob_sz:
-    ucode_blob += "\x00" * (want_blob_sz - ucode_blob_sz)
+    ucode_blob += b"\x00" * (want_blob_sz - ucode_blob_sz)
 elif ucode_blob_sz > want_blob_sz:
     ucode_blob = ucode_blob[:want_blob_sz]
 
 if ucode_jt_sz < want_jt_sz:
-    ucode_jt += ucode_jt[-4:] * ((want_jt_sz - ucode_jt_sz) / 4)
+    ucode_jt += ucode_jt[-4:] * ((want_jt_sz - ucode_jt_sz) // 4)
 elif ucode_jt_sz > want_jt_sz:
     ucode_jt = ucode_jt[:want_jt_sz]
 
-sub_hdr = struct.pack("<III212x", ucode_feature_version, want_blob_sz / 4, want_jt_sz / 4)
+sub_hdr = struct.pack("<III212x", ucode_feature_version, want_blob_sz // 4, want_jt_sz // 4)
 payload = sub_hdr + ucode_blob + ucode_jt
 assert len(payload) == want_size + 0xe0
 crc = zlib.crc32(payload)


### PR DESCRIPTION
As a perfect 3am idea, I decided to adapt f32 to be python3 compatible.
Note that I don't really know python so my changes may or may not be "good". I used the sample commands in the READMEs to test functionality so anything not covered there might still be broken.