### PR TITLE
Make rai tools python3 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-# radeon-tools
-
-Tools for working with various radeon related files, as released by fail0verflow.
-See individual directories for detailed information.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# radeon-tools
+
+Tools for working with various radeon related files, as released by fail0verflow.
+See individual directories for detailed information.

--- a/rai/README.md
+++ b/rai/README.md
@@ -10,15 +10,15 @@ You need PLY installed (`pip install ply`) for this to work.
 Obtain a RAI file (e.g. bonaire.rai) and parse it into pickle format:
 
 ```shell
-$ python raiparse.py bonaire.rai bonaire.pickle
+$ python3 raiparse.py bonaire.rai bonaire.pickle
 ```
 
 Then you can explain individual registers by offset or name:
 
 ```shell
-$ python showreg.py GpuF0Reg '0xb02<<2' 
+$ python3 showreg.py GpuF0Reg '0xb02<<2' 
 - or -
-$ python showregname.py HDP_NONSURFACE_INFO
+$ python3 showregname.py HDP_NONSURFACE_INFO
 HDP_NONSURFACE_INFO (GpuF0Reg:0x2c08,GpuF1Reg:0x2c08) 32bit:
        0  NONSURF_ADDR_TYPE
           - 0: physical address with no translation. 
@@ -32,7 +32,7 @@ HDP_NONSURFACE_INFO (GpuF0Reg:0x2c08,GpuF1Reg:0x2c08) 32bit:
 Or dump the entire address list:
 
 ```shell
-$ python addresslist.py GpuF0Reg
+$ python3 addresslist.py GpuF0Reg
 0x0 MM_INDEX
 0x4 MM_DATA
 0x18 MM_INDEX_HI
@@ -50,7 +50,7 @@ Or get a bunch of C-style #defines and debug print calls, suitable for kernel
 driver debugging:
 
 ```shell
-$ python defines.py GpuF0Reg
+$ python3 defines.py GpuF0Reg
 #define MM_INDEX 0x0
 #define MM_DATA 0x4
 #define MM_INDEX_HI 0x18
@@ -68,7 +68,7 @@ $ python defines.py GpuF0Reg
 You can also dump the entire database:
 
 ```shell
-$ python dumpmap.py GpuF0Reg
+$ python3 dumpmap.py GpuF0Reg
 ChipInfo:
   RELEASE: 'Chip Spec 0.28'
   ASIC_VENDOR_ID: 4098
@@ -86,7 +86,7 @@ If you take some live register dumps from the hardware, you can decode them
 into readable form:
 
 ```shell
-$ python dumpregs.py GpuF0Reg examples/regs_linux.dump
+$ python3 dumpregs.py GpuF0Reg examples/regs_linux.dump
 MM_INDEX (GpuBlockIO:0x0,GpuF0Reg:0x0,GpuF1Reg:0x0) 32bit: 0x6998
     30:0  MM_OFFSET = 0x6998
       31  MM_APER = 0x0
@@ -97,7 +97,7 @@ MM_INDEX (GpuBlockIO:0x0,GpuF0Reg:0x0,GpuF1Reg:0x0) 32bit: 0x6998
 And diff two dumps:
 
 ```diff
-$ python diffregs.py GpuF0Reg examples/regs_fbsd.dump examples/regs_linux.dump
+$ python3 diffregs.py GpuF0Reg examples/regs_fbsd.dump examples/regs_linux.dump
 -MM_INDEX (GpuBlockIO:0x0,GpuF0Reg:0x0,GpuF1Reg:0x0) 32bit: 0x6610
 +MM_INDEX (GpuBlockIO:0x0,GpuF0Reg:0x0,GpuF1Reg:0x0) 32bit: 0x6998
 -    30:0  MM_OFFSET = 0x6610

--- a/rai/addresslist.py
+++ b/rai/addresslist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import sys
 from rai import *
 rai = load_default_rai()
@@ -8,8 +8,8 @@ space = sys.argv[1]
 try:
     space = rai.chip_spaces[space]
 except KeyError:
-    print "Unknown ChipSpace"
+    print("Unknown ChipSpace")
     sys.exit(0)
 
 for addr, reg in sorted(space.addrs.items()):
-    print "0x%x %s" % (addr, reg.name)
+    print("0x%x %s" % (addr, reg.name))

--- a/rai/defines.py
+++ b/rai/defines.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import sys
 from rai import *
 
@@ -9,13 +9,13 @@ space = sys.argv[1]
 try:
     space = rai.chip_spaces[space]
 except KeyError:
-    print "Unknown ChipSpace"
+    print("Unknown ChipSpace")
     sys.exit(0)
 
 for addr, reg in sorted(space.addrs.items()):
-    print "#define %s 0x%x" % (reg.name, addr)
+    print("#define %s 0x%x" % (reg.name, addr))
 
 for addr, reg in sorted(space.addrs.items()):
-    print """    dev_info(rdev->dev, "  %s=0x%%08X\\n",
+    print("""    dev_info(rdev->dev, "  %s=0x%%08X\\n",
         RREG32(%s));
-""" % (reg.name, reg.name)
+""" % (reg.name, reg.name))

--- a/rai/diffregs.py
+++ b/rai/diffregs.py
@@ -1,11 +1,11 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import sys, struct, difflib
 from rai import *
 
 rai = load_default_rai()
 
-dumpa = open(sys.argv[2]).read()
-dumpb = open(sys.argv[3]).read()
+dumpa = open(sys.argv[2], "rb").read()
+dumpb = open(sys.argv[3], "rb").read()
 
 space = rai.chip_spaces[sys.argv[1]]
 
@@ -23,9 +23,9 @@ for addr in range(0, len(dumpa), 4):
         reg = space.addrs[addr]
 
     except KeyError:
-        print "-UNK[0x%x]: 0x%x" % (addr, va)
-        print "+UNK[0x%x]: 0x%x" % (addr, vb)
-        print
+        print("-UNK[0x%x]: 0x%x" % (addr, va))
+        print("+UNK[0x%x]: 0x%x" % (addr, vb))
+        print("")
         continue
     la = split(reg.value(va))
     lb = split(reg.value(vb))

--- a/rai/dumpmap.py
+++ b/rai/dumpmap.py
@@ -1,8 +1,8 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import sys
 from rai import *
 
 rai = load_default_rai()
 
 
-print str(rai)
+print(str(rai))

--- a/rai/dumpregs.py
+++ b/rai/dumpregs.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import sys, struct, difflib
 from rai import *
 
 rai = load_default_rai()
 
-dumpa = open(sys.argv[2]).read()
+dumpa = open(sys.argv[2], "rb").read()
 
 space = rai.chip_spaces[sys.argv[1]]
 
@@ -15,8 +15,8 @@ for addr in range(0, len(dumpa), 4):
         reg = space.addrs[addr]
 
     except KeyError:
-        print "UNK[0x%x]: 0x%x" % (addr, va)
-        print
+        print("UNK[0x%x]: 0x%x" % (addr, va))
+        print("")
         continue
 
-    print reg.value(va)
+    print(reg.value(va))

--- a/rai/rai.py
+++ b/rai/rai.py
@@ -1,4 +1,5 @@
-import cPickle
+#!/usr/bin/python3
+import pickle
 
 def it(s, pfx="  "):
     return pfx + str(s).replace("\n", "\n"+pfx)[:-len(pfx)]
@@ -84,5 +85,5 @@ class Range(tuple):
     pass
 
 def load_default_rai():
-    return cPickle.load(open("bonaire.pickle"))
+    return pickle.load(open("bonaire.pickle", "rb"))
 

--- a/rai/raiparse.py
+++ b/rai/raiparse.py
@@ -1,4 +1,5 @@
-import sys, cPickle
+#!/usr/bin/python3
+import sys, pickle
 import ply.lex as lex
 import ply.yacc as yacc
 from rai import *
@@ -328,5 +329,5 @@ def p_error(t):
 parser = yacc.yacc(debug=1)
 
 rai = parser.parse(open(sys.argv[1]).read())
-with open(sys.argv[2], "w") as fd:
-    cPickle.dump(rai, fd)
+with open(sys.argv[2], "wb") as fd:
+    pickle.dump(rai, fd)

--- a/rai/showreg.py
+++ b/rai/showreg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import sys
 from rai import *
 
@@ -15,16 +15,16 @@ else:
 try:
     space = rai.chip_spaces[space]
 except KeyError:
-    print "Unknown ChipSpace"
+    print("Unknown ChipSpace")
     sys.exit(0)
 
 try:
     reg = space.addrs[addr]
 except KeyError:
-    print "Unknown Register"
+    print("Unknown Register")
     sys.exit(0)
 
 if len(sys.argv) < 4:
-    print reg
+    print(reg)
 else:
-    print reg.value(int(sys.argv[3], 0))
+    print(reg.value(int(sys.argv[3], 0)))

--- a/rai/showregname.py
+++ b/rai/showregname.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import sys
 from rai import *
 rai = load_default_rai()
@@ -9,12 +9,12 @@ for bname, block in rai.blocks.items():
     if reg in block.registers:
         break
 else:
-    print "Unknown register"
+    print("Unknown register")
     sys.exit(0)
 
 reg = block.registers[reg]
 
 if len(sys.argv) < 3:
-    print reg
+    print(reg)
 else:
-    print reg.value(int(sys.argv[2], 0))
+    print(reg.value(int(sys.argv[2], 0)))


### PR DESCRIPTION
As with #1, I made all rai tools python3 compatible. Same disclaimer applies here, I don't really write python and used the README as test suite. Anything not covered there may still be broken.